### PR TITLE
Add offset to each element

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4853,9 +4853,9 @@
       "dev": true
     },
     "nyc": {
-      "version": "13.2.0",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-13.2.0.tgz",
-      "integrity": "sha512-gQBlOqvfpYt9b2PZ7qElrHWt8x4y8ApNfbMBoDPdl3sY4/4RJwCxDGTSqhA9RnaguZjS5nW7taW8oToe86JLgQ==",
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-13.3.0.tgz",
+      "integrity": "sha512-P+FwIuro2aFG6B0Esd9ZDWUd51uZrAEoGutqZxzrVmYl3qSfkLgcQpBPBjtDFsUQLFY1dvTQJPOyeqr8S9GF8w==",
       "dev": true,
       "requires": {
         "archy": "^1.0.0",
@@ -4868,10 +4868,10 @@
         "glob": "^7.1.3",
         "istanbul-lib-coverage": "^2.0.3",
         "istanbul-lib-hook": "^2.0.3",
-        "istanbul-lib-instrument": "^3.0.1",
+        "istanbul-lib-instrument": "^3.1.0",
         "istanbul-lib-report": "^2.0.4",
         "istanbul-lib-source-maps": "^3.0.2",
-        "istanbul-reports": "^2.1.0",
+        "istanbul-reports": "^2.1.1",
         "make-dir": "^1.3.0",
         "merge-source-map": "^1.1.0",
         "resolve-from": "^4.0.0",
@@ -4908,11 +4908,11 @@
           "dev": true
         },
         "async": {
-          "version": "2.6.1",
+          "version": "2.6.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "lodash": "^4.17.10"
+            "lodash": "^4.17.11"
           }
         },
         "balanced-match": {
@@ -4928,11 +4928,6 @@
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
-        },
-        "builtin-modules": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true
         },
         "caching-transform": {
           "version": "3.0.1",
@@ -5132,7 +5127,7 @@
           "dev": true
         },
         "handlebars": {
-          "version": "4.0.12",
+          "version": "4.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -5195,14 +5190,6 @@
           "version": "0.2.1",
           "bundled": true,
           "dev": true
-        },
-        "is-builtin-module": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "builtin-modules": "^1.0.0"
-          }
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
@@ -5272,11 +5259,11 @@
           }
         },
         "istanbul-reports": {
-          "version": "2.1.0",
+          "version": "2.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "handlebars": "^4.0.11"
+            "handlebars": "^4.1.0"
           }
         },
         "json-parse-better-errors": {
@@ -5348,13 +5335,13 @@
           }
         },
         "mem": {
-          "version": "4.0.0",
+          "version": "4.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "map-age-cleaner": "^0.1.1",
             "mimic-fn": "^1.0.0",
-            "p-is-promise": "^1.1.0"
+            "p-is-promise": "^2.0.0"
           }
         },
         "merge-source-map": {
@@ -5416,12 +5403,12 @@
           "dev": true
         },
         "normalize-package-data": {
-          "version": "2.4.0",
+          "version": "2.5.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "hosted-git-info": "^2.1.4",
-            "is-builtin-module": "^1.0.0",
+            "resolve": "^1.10.0",
             "semver": "2 || 3 || 4 || 5",
             "validate-npm-package-license": "^3.0.1"
           }
@@ -5482,7 +5469,7 @@
           "dev": true
         },
         "p-is-promise": {
-          "version": "1.1.0",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true
         },
@@ -5539,6 +5526,11 @@
         },
         "path-key": {
           "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "path-parse": {
+          "version": "1.0.6",
           "bundled": true,
           "dev": true
         },
@@ -5613,6 +5605,14 @@
           "version": "1.0.1",
           "bundled": true,
           "dev": true
+        },
+        "resolve": {
+          "version": "1.10.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
         },
         "resolve-from": {
           "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint": "^5.13.0",
     "eslint-plugin-babel": "^5.3.0",
     "mocha": "^5.2.0",
-    "nyc": "^13.2.0",
+    "nyc": "^13.3.0",
     "webpack": "^4.29.3",
     "webpack-cli": "^3.2.3",
     "webpack-dev-server": "^3.1.14"

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,9 @@ module.exports = function parseXml(xml, options = emptyObject) {
     pos = 1;
   }
 
-  //TODO: xml = xml.replace(/\r\n/g, '\n'); // Normalize CRLF to LF.
+  if (!options.addOffsets) {
+    xml = xml.replace(/\r\n/g, '\n'); // Normalize CRLF to LF.
+  }
 
   let doc = {
     type: NODE_TYPE_DOCUMENT,
@@ -182,10 +184,10 @@ function consumeElement(state) {
   let node = {
     type: NODE_TYPE_ELEMENT,
     name,
-    offset: posStart,
     attributes: parsedAttrs,
     children: []
   };
+  if (state.options.addOffsets) { node.offset = posStart; }
 
   let xmlSpace = parsedAttrs['xml:space'];
 

--- a/src/index.js
+++ b/src/index.js
@@ -25,12 +25,13 @@ module.exports = function parseXml(xml, options = emptyObject) {
     Syntax = require('./lib/syntax');
   }
 
+  let pos = 0;
   if (xml[0] === '\uFEFF') {
     // Strip byte order mark.
-    xml = xml.slice(1);
+    pos = 1;
   }
 
-  xml = xml.replace(/\r\n/g, '\n'); // Normalize CRLF to LF.
+  //TODO: xml = xml.replace(/\r\n/g, '\n'); // Normalize CRLF to LF.
 
   let doc = {
     type: NODE_TYPE_DOCUMENT,
@@ -43,7 +44,7 @@ module.exports = function parseXml(xml, options = emptyObject) {
     length: xml.length,
     options,
     parent: doc,
-    pos: 0,
+    pos: pos,
     prevPos: 0,
     slice: null,
     xml
@@ -163,6 +164,7 @@ function consumeDoctypeDecl(state) {
 }
 
 function consumeElement(state) {
+  const posStart = state.pos;
   let [ tag, name, attrs ] = scan(state, Syntax.Anchored.EmptyElemTag);
   let isEmpty = tag !== void 0;
 
@@ -180,6 +182,7 @@ function consumeElement(state) {
   let node = {
     type: NODE_TYPE_ELEMENT,
     name,
+    offset: posStart,
     attributes: parsedAttrs,
     children: []
   };


### PR DESCRIPTION
In order to show the users the whereabouts of each tag in the original XML string, I added an `offset` value on each element node; to do that I needed to remove the `\r\n` conversion (as that would change the offsets).
If that feature is not interesting to you, feel free to close the PR (and I will publish my fork on NPM [under our namespace](https://www.npmjs.com/~andxor)).