### PR TITLE
Fix catastrophic backtracking with reference RegExp. Fixes issue #9.

### DIFF
--- a/src/lib/syntax.js
+++ b/src/lib/syntax.js
@@ -86,7 +86,7 @@ exports.Name = regex`
 // Loose implementation. The entity will be validated in the `replaceReference`
 // function.
 exports.Reference = regex`
-  &\S+?;
+  &[^\s&]+?;
 `;
 
 exports.S = regex`

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -332,6 +332,17 @@ describe("parseXml()", () => {
       assert.equal(root.attributes.c, " a   z ");
       assert.equal(root.attributes.d, " a   z ");
     });
+
+    it("should handle many character references in a single attribute", () => {
+      {
+        let [ root ] = parseXml('<a b="&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;"/>').children;
+        assert.equal(root.attributes.b, "<".repeat(35));
+      }
+      {
+        let [ root ] = parseXml('<a b="&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;"></a>').children;
+        assert.equal(root.attributes.b, "<".repeat(35));
+      }
+    });
   });
 });
 


### PR DESCRIPTION
This PR excludes `&` from the reference regex. I have not checked over any other regexes for any other backtracking issues.