### PR TITLE
Lossen attribute and reference regex, validate later

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -380,6 +380,10 @@ function parseAttrs(state, attrs) {
 function replaceReference(ref) {
   let state = this; // eslint-disable-line no-invalid-this
 
+  if (ref[ref.length-1] !== ';') {
+    error(state, `Invalid reference: \`${ref}\``);
+  }
+
   if (ref[1] === '#') {
     // This is a character entity.
     let codePoint;

--- a/src/lib/syntax.js
+++ b/src/lib/syntax.js
@@ -86,7 +86,7 @@ exports.Name = regex`
 // Loose implementation. The entity will be validated in the `replaceReference`
 // function.
 exports.Reference = regex`
-  &[^\s&]+?;
+  &[^\s&;]*;?
 `;
 
 exports.S = regex`
@@ -106,13 +106,13 @@ exports.Attribute = regex`
 
   (?:
     "(?:
-      [^<&"] | ${exports.Reference}
+      [^<"]
     )*"
 
     |
 
     '(?:
-      [^<&'] | ${exports.Reference}
+      [^<']
     )*'
   )
 `;

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -343,6 +343,10 @@ describe("parseXml()", () => {
         assert.equal(root.attributes.b, "<".repeat(35));
       }
     });
+
+    it("should handle very long elements without RangeError", () => {
+        parseXml(`<a b="${'c'.repeat(9000000)}"/>`);
+    });
   });
 });
 


### PR DESCRIPTION
This is a potential fix for #12, with all tests passing.

I tried various updates to the `Attribute` regex that would still include the `Reference` regex while avoiding the RangeError, but I was unable to avoid either a "hang" (catastrophic backtracking) or the RangeError, so I went with a different approach.

Here's what I've done
- Remove the `Reference` regex from the `Attribute` regex, and instead just allow all `&` characters (references validated later)
- Further loosen the `Reference` regex to capture any `&...` with an additional check added in `replaceReference`