### PR TITLE
Add back node v10 support

### DIFF
--- a/.github/workflows/testAndLint.yml
+++ b/.github/workflows/testAndLint.yml
@@ -8,6 +8,7 @@ jobs:
     strategy:
       matrix:
         node:
+          - '10'
           - '12'
           - '14'
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/rgrove/parse-xml.git"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": "10 || >=12.0.0"
   },
   "files": [
     "dist",


### PR DESCRIPTION
Thanks for the great work on this library. Node v10 is about to reach the end of its lifetime but it's still being actively used in most cloud platforms.