### PR TITLE
Add optional byte offsets to nodes

### DIFF
--- a/src/lib/Parser.ts
+++ b/src/lib/Parser.ts
@@ -773,8 +773,8 @@ export class Parser {
 // -- Private Functions --------------------------------------------------------
 
 /**
- * Normalizes the given XML string by stripping a byte order mark (if present)
- * and replacing CRLF sequences and lone CR characters with LF characters.
+ * Normalizes the given XML string by replacing CRLF sequences and lone CR
+ * characters with LF characters.
  */
 function normalizeXmlString(xml: string): string {
   return xml.replace(/\r\n?/g, '\n');

--- a/src/lib/StringScanner.ts
+++ b/src/lib/StringScanner.ts
@@ -43,16 +43,6 @@ export class StringScanner {
   // -- Protected Methods ------------------------------------------------------
 
   /**
-   * Returns the byte index of the given character index in the string. The two
-   * may differ in strings that contain multibyte characters.
-   */
-  protected charIndexToByteIndex(charIndex: number = this.charIndex): number {
-    return this.multiByteMode
-      ? (this.charsToBytes as number[])[charIndex] ?? Infinity
-      : charIndex;
-  }
-
-  /**
    * Returns the number of characters in the given string, which may differ from
    * the byte length if the string contains multibyte characters.
    */
@@ -73,6 +63,16 @@ export class StringScanner {
    */
   advance(count = 1) {
     this.charIndex = Math.min(this.charCount, this.charIndex + count);
+  }
+
+  /**
+   * Returns the byte index of the given character index in the string. The two
+   * may differ in strings that contain multibyte characters.
+   */
+  charIndexToByteIndex(charIndex: number = this.charIndex): number {
+    return this.multiByteMode
+      ? (this.charsToBytes as number[])[charIndex] ?? Infinity
+      : charIndex;
   }
 
   /**

--- a/src/lib/XmlNode.ts
+++ b/src/lib/XmlNode.ts
@@ -37,6 +37,12 @@ export class XmlNode {
   static readonly TYPE_TEXT = 'text';
 
   /**
+   * Byte offset of this node in the original XML string, or `-1` if the offset
+   * is unknown.
+   */
+  offset = -1;
+
+  /**
    * Parent node of this node, or `null` if this node has no parent.
    */
   parent: XmlDocument | XmlElement | null = null;
@@ -100,6 +106,10 @@ export class XmlNode {
 
     if (this.preserveWhitespace) {
       json.preserveWhitespace = true;
+    }
+
+    if (this.offset !== -1) {
+      json.offset = this.offset;
     }
 
     return json;

--- a/src/lib/XmlNode.ts
+++ b/src/lib/XmlNode.ts
@@ -37,12 +37,6 @@ export class XmlNode {
   static readonly TYPE_TEXT = 'text';
 
   /**
-   * Byte offset of this node in the original XML string, or `-1` if the offset
-   * is unknown.
-   */
-  offset = -1;
-
-  /**
    * Parent node of this node, or `null` if this node has no parent.
    */
   parent: XmlDocument | XmlElement | null = null;
@@ -54,6 +48,12 @@ export class XmlNode {
   get document(): XmlDocument | null {
     return this.parent?.document ?? null;
   }
+
+  /**
+   * Ending byte offset of this node in the original XML string, or `-1` if the
+   * offset is unknown.
+   */
+  end = -1;
 
   /**
    * Whether this node is the root node of the document.
@@ -76,6 +76,12 @@ export class XmlNode {
   get preserveWhitespace(): boolean {
     return Boolean(this.parent?.preserveWhitespace);
   }
+
+  /**
+   * Starting byte offset of this node in the original XML string, or `-1` if
+   * the offset is unknown.
+   */
+  start = -1;
 
   /**
    * Type of this node.
@@ -108,8 +114,9 @@ export class XmlNode {
       json.preserveWhitespace = true;
     }
 
-    if (this.offset !== -1) {
-      json.offset = this.offset;
+    if (this.start !== -1) {
+      json.start = this.start;
+      json.end = this.end;
     }
 
     return json;

--- a/src/lib/XmlNode.ts
+++ b/src/lib/XmlNode.ts
@@ -42,18 +42,24 @@ export class XmlNode {
   parent: XmlDocument | XmlElement | null = null;
 
   /**
-   * Document that contains this node, or `null` if this node is not associated
-   * with a document.
+   * Starting byte offset of this node in the original XML string, or `-1` if
+   * the offset is unknown.
    */
-  get document(): XmlDocument | null {
-    return this.parent?.document ?? null;
-  }
+  start = -1;
 
   /**
    * Ending byte offset of this node in the original XML string, or `-1` if the
    * offset is unknown.
    */
   end = -1;
+
+  /**
+   * Document that contains this node, or `null` if this node is not associated
+   * with a document.
+   */
+  get document(): XmlDocument | null {
+    return this.parent?.document ?? null;
+  }
 
   /**
    * Whether this node is the root node of the document.
@@ -76,12 +82,6 @@ export class XmlNode {
   get preserveWhitespace(): boolean {
     return Boolean(this.parent?.preserveWhitespace);
   }
-
-  /**
-   * Starting byte offset of this node in the original XML string, or `-1` if
-   * the offset is unknown.
-   */
-  start = -1;
 
   /**
    * Type of this node.

--- a/src/lib/syntax.ts
+++ b/src/lib/syntax.ts
@@ -20,7 +20,7 @@ export const attValueCharSingleQuote = /[^'&<]+/y;
  *
  * @see https://www.w3.org/TR/2008/REC-xml-20081126/#AVNormalize
  */
-export const attValueNormalizedWhitespace = /[\t\n]/g;
+export const attValueNormalizedWhitespace = /\r\n|[\n\r\t]/g;
 
 /**
  * Regular expression that matches one or more characters that signal the end of

--- a/tests/lib/Parser.test.js
+++ b/tests/lib/Parser.test.js
@@ -52,6 +52,23 @@ describe('Parser', () => {
     });
   });
 
+  describe('when `options.includeOffsets` is `true`', () => {
+    it('the offset is a byte offset, not a character offset', () => {
+      let { root } = parseXml('<root><cat>🐈</cat><dog>🐕</dog></root>', { includeOffsets: true });
+      assert.strictEqual(root.children[1].offset, 19);
+    });
+
+    it('a byte order mark character is counted in the offset', () => {
+      let { root } = parseXml('\uFEFF<root>foo</root>', { includeOffsets: true });
+      assert.strictEqual(root.children[0].offset, 7);
+    });
+
+    it('a carriage return character is not counted in the offset', () => {
+      let { root } = parseXml('<root>\rfoo</root>', { includeOffsets: true });
+      assert.strictEqual(root.children[0].offset, 6);
+    });
+  });
+
   describe('when `options.resolveUndefinedEntity` is set', () => {
     beforeEach(() => {
       options.resolveUndefinedEntity = (ref) => {

--- a/tests/lib/Parser.test.js
+++ b/tests/lib/Parser.test.js
@@ -58,19 +58,24 @@ describe('Parser', () => {
   });
 
   describe('when `options.includeOffsets` is `true`', () => {
-    it('the offset is a byte offset, not a character offset', () => {
+    it('the start offset is a byte offset, not a character offset', () => {
       let { root } = parseXml('<root><cat>🐈</cat><dog>🐕</dog></root>', { includeOffsets: true });
-      assert.strictEqual(root.children[1].offset, 19);
+      assert.strictEqual(root.children[1].start, 19);
+    });
+
+    it('the end offset is a byte offset, not a character offset', () => {
+      let { root } = parseXml('<root><cat>🐈</cat><dog>🐕</dog></root>', { includeOffsets: true });
+      assert.strictEqual(root.children[1].end, 32);
     });
 
     it('a byte order mark character is counted in the offset', () => {
       let { root } = parseXml('\uFEFF<root>foo</root>', { includeOffsets: true });
-      assert.strictEqual(root.children[0].offset, 7);
+      assert.strictEqual(root.children[0].start, 7);
     });
 
     it('a carriage return character is not counted in the offset', () => {
       let { root } = parseXml('<root>\rfoo</root>', { includeOffsets: true });
-      assert.strictEqual(root.children[0].offset, 6);
+      assert.strictEqual(root.children[0].start, 6);
     });
   });
 

--- a/tests/lib/Parser.test.js
+++ b/tests/lib/Parser.test.js
@@ -40,6 +40,11 @@ describe('Parser', () => {
     assert.strictEqual(doc.root.name, 'root');
   });
 
+  it('normalizes whitespace in attribute values', () => {
+    let { root } = parseXml('<root attr=" one two\tthree\nfour\r\nfive\rsix " />');
+    assert.strictEqual(root.attributes.attr, ' one two three four five six ');
+  });
+
   describe('when `options.ignoreUndefinedEntities` is `true`', () => {
     beforeEach(() => {
       options.ignoreUndefinedEntities = true;

--- a/tests/lib/XmlCdata.test.js
+++ b/tests/lib/XmlCdata.test.js
@@ -26,18 +26,34 @@ describe('XmlCdata', () => {
     assert.strictEqual(node.parent, root);
   });
 
-  describe('offset', () => {
-    describe('when `options.includeOffsets` is `false`', () => {
+  describe('when `options.includeOffsets` is `false`', () => {
+    describe('start', () => {
       it('is `-1`', () => {
         let { root } = parseXml(xml, { preserveCdata: true });
-        assert.strictEqual(root.children[0].offset, -1);
+        assert.strictEqual(root.children[0].start, -1);
       });
     });
 
-    describe('when `options.includeOffsets` is `true`', () => {
-      it('is the byte offset of the CDATA section', () => {
+    describe('end', () => {
+      it('is `-1`', () => {
+        let { root } = parseXml(xml, { preserveCdata: true });
+        assert.strictEqual(root.children[0].end, -1);
+      });
+    });
+  });
+
+  describe('when `options.includeOffsets` is `true`', () => {
+    describe('start', () => {
+      it('is the starting byte offset of the CDATA section', () => {
         let { root } = parseXml(xml, { includeOffsets: true, preserveCdata: true });
-        assert.strictEqual(root.children[0].offset, 6);
+        assert.strictEqual(root.children[0].start, 6);
+      });
+    });
+
+    describe('end', () => {
+      it('is the ending byte offset of the CDATA section', () => {
+        let { root } = parseXml(xml, { includeOffsets: true, preserveCdata: true });
+        assert.strictEqual(root.children[0].end, 33);
       });
     });
   });

--- a/tests/lib/XmlCdata.test.js
+++ b/tests/lib/XmlCdata.test.js
@@ -26,6 +26,22 @@ describe('XmlCdata', () => {
     assert.strictEqual(node.parent, root);
   });
 
+  describe('offset', () => {
+    describe('when `options.includeOffsets` is `false`', () => {
+      it('is `-1`', () => {
+        let { root } = parseXml(xml, { preserveCdata: true });
+        assert.strictEqual(root.children[0].offset, -1);
+      });
+    });
+
+    describe('when `options.includeOffsets` is `true`', () => {
+      it('is the byte offset of the CDATA section', () => {
+        let { root } = parseXml(xml, { includeOffsets: true, preserveCdata: true });
+        assert.strictEqual(root.children[0].offset, 6);
+      });
+    });
+  });
+
   describe('type', () => {
     it('is `XmlNode.TYPE_CDATA`', () => {
       let { root } = parseXml(xml, { preserveCdata: true });

--- a/tests/lib/XmlComment.test.js
+++ b/tests/lib/XmlComment.test.js
@@ -35,18 +35,34 @@ describe('XmlComment', () => {
     });
   });
 
-  describe('offset', () => {
-    describe('when `options.includeOffsets` is `false`', () => {
+  describe('when `options.includeOffsets` is `false`', () => {
+    describe('start', () => {
       it('is `-1`', () => {
         let { root } = parseXml(`<root><!-- I'm a comment! --></root>`, { preserveComments: true });
-        assert.strictEqual(root.children[0].offset, -1);
+        assert.strictEqual(root.children[0].start, -1);
       });
     });
 
-    describe('when `options.includeOffsets` is `true`', () => {
-      it('is the byte offset of the comment', () => {
+    describe('end', () => {
+      it('is `-1`', () => {
+        let { root } = parseXml(`<root><!-- I'm a comment! --></root>`, { preserveComments: true });
+        assert.strictEqual(root.children[0].end, -1);
+      });
+    });
+  });
+
+  describe('when `options.includeOffsets` is `true`', () => {
+    describe('start', () => {
+      it('is the starting byte offset of the comment', () => {
         let { root } = parseXml(`<root><!-- I'm a comment! --></root>`, { includeOffsets: true, preserveComments: true });
-        assert.strictEqual(root.children[0].offset, 6);
+        assert.strictEqual(root.children[0].start, 6);
+      });
+    });
+
+    describe('end', () => {
+      it('is the ending byte offset of the comment', () => {
+        let { root } = parseXml(`<root><!-- I'm a comment! --></root>`, { includeOffsets: true, preserveComments: true });
+        assert.strictEqual(root.children[0].end, 29);
       });
     });
   });

--- a/tests/lib/XmlComment.test.js
+++ b/tests/lib/XmlComment.test.js
@@ -35,6 +35,22 @@ describe('XmlComment', () => {
     });
   });
 
+  describe('offset', () => {
+    describe('when `options.includeOffsets` is `false`', () => {
+      it('is `-1`', () => {
+        let { root } = parseXml(`<root><!-- I'm a comment! --></root>`, { preserveComments: true });
+        assert.strictEqual(root.children[0].offset, -1);
+      });
+    });
+
+    describe('when `options.includeOffsets` is `true`', () => {
+      it('is the byte offset of the comment', () => {
+        let { root } = parseXml(`<root><!-- I'm a comment! --></root>`, { includeOffsets: true, preserveComments: true });
+        assert.strictEqual(root.children[0].offset, 6);
+      });
+    });
+  });
+
   describe('parent', () => {
     it('is the parent node', () => {
       let { root } = parseXml(`<root><!-- I'm a comment! --></root>`, { preserveComments: true });

--- a/tests/lib/XmlDocument.test.js
+++ b/tests/lib/XmlDocument.test.js
@@ -39,6 +39,22 @@ describe('XmlDocument', () => {
     });
   });
 
+  describe('offset', () => {
+    describe('when `options.includeOffsets` is `false`', () => {
+      it('is `-1`', () => {
+        let doc = parseXml('<root />');
+        assert.strictEqual(doc.offset, -1);
+      });
+    });
+
+    describe('when `options.includeOffsets` is `true`', () => {
+      it('is the byte offset of the document (which is always `0`)', () => {
+        let doc = parseXml('<root />', { includeOffsets: true });
+        assert.strictEqual(doc.offset, 0);
+      });
+    });
+  });
+
   describe('parent', () => {
     it('is `null`', () => {
       assert.strictEqual(parseXml('<root />').parent, null);

--- a/tests/lib/XmlDocument.test.js
+++ b/tests/lib/XmlDocument.test.js
@@ -39,18 +39,34 @@ describe('XmlDocument', () => {
     });
   });
 
-  describe('offset', () => {
-    describe('when `options.includeOffsets` is `false`', () => {
+  describe('when `options.includeOffsets` is `false`', () => {
+    describe('start', () => {
       it('is `-1`', () => {
         let doc = parseXml('<root />');
-        assert.strictEqual(doc.offset, -1);
+        assert.strictEqual(doc.start, -1);
       });
     });
 
-    describe('when `options.includeOffsets` is `true`', () => {
-      it('is the byte offset of the document (which is always `0`)', () => {
+    describe('end', () => {
+      it('is `-1`', () => {
+        let doc = parseXml('<root />');
+        assert.strictEqual(doc.end, -1);
+      });
+    });
+  });
+
+  describe('when `options.includeOffsets` is `true`', () => {
+    describe('start', () => {
+      it('is the starting byte offset of the document', () => {
         let doc = parseXml('<root />', { includeOffsets: true });
-        assert.strictEqual(doc.offset, 0);
+        assert.strictEqual(doc.start, 0);
+      });
+    });
+
+    describe('end', () => {
+      it('is the ending byte offset of the document', () => {
+        let doc = parseXml('<root />', { includeOffsets: true });
+        assert.strictEqual(doc.end, 8);
       });
     });
   });

--- a/tests/lib/XmlElement.test.js
+++ b/tests/lib/XmlElement.test.js
@@ -129,6 +129,24 @@ describe('XmlElement', () => {
     });
   });
 
+  describe('offset', () => {
+    describe('when `options.includeOffsets` is `false`', () => {
+      it('is `-1`', () => {
+        let { root } = parseXml('<root />');
+        assert.strictEqual(root.offset, -1);
+      });
+    });
+
+    describe('when `options.includeOffsets` is `true`', () => {
+      it('is the offset of the element in the document', () => {
+        let { root } = parseXml('<a><b><c /></b></a>', { includeOffsets: true });
+        assert.strictEqual(root.offset, 0);
+        assert.strictEqual(root.children[0].offset, 3);
+        assert.strictEqual(root.children[0].children[0].offset, 6);
+      });
+    });
+  });
+
   describe('parent', () => {
     describe('when the element is the root element', () => {
       it('is the document', () => {

--- a/tests/lib/XmlElement.test.js
+++ b/tests/lib/XmlElement.test.js
@@ -129,20 +129,38 @@ describe('XmlElement', () => {
     });
   });
 
-  describe('offset', () => {
-    describe('when `options.includeOffsets` is `false`', () => {
+  describe('when `options.includeOffsets` is `false`', () => {
+    describe('start', () => {
       it('is `-1`', () => {
         let { root } = parseXml('<root />');
-        assert.strictEqual(root.offset, -1);
+        assert.strictEqual(root.start, -1);
       });
     });
 
-    describe('when `options.includeOffsets` is `true`', () => {
-      it('is the offset of the element in the document', () => {
+    describe('end', () => {
+      it('is `-1`', () => {
+        let { root } = parseXml('<root />');
+        assert.strictEqual(root.end, -1);
+      });
+    });
+  });
+
+  describe('when `options.includeOffsets` is `true`', () => {
+    describe('start', () => {
+      it('is the starting byte offset of the element', () => {
         let { root } = parseXml('<a><b><c /></b></a>', { includeOffsets: true });
-        assert.strictEqual(root.offset, 0);
-        assert.strictEqual(root.children[0].offset, 3);
-        assert.strictEqual(root.children[0].children[0].offset, 6);
+        assert.strictEqual(root.start, 0);
+        assert.strictEqual(root.children[0].start, 3);
+        assert.strictEqual(root.children[0].children[0].start, 6);
+      });
+    });
+
+    describe('end', () => {
+      it('is the ending byte offset of the element', () => {
+        let { root } = parseXml('<a><b><c /></b></a>', { includeOffsets: true });
+        assert.strictEqual(root.end, 19);
+        assert.strictEqual(root.children[0].end, 15);
+        assert.strictEqual(root.children[0].children[0].end, 11);
       });
     });
   });

--- a/tests/lib/XmlNode.test.js
+++ b/tests/lib/XmlNode.test.js
@@ -15,6 +15,23 @@ describe('XmlNode', () => {
     });
   });
 
+  describe('toJSON()', () => {
+    describe('when `offset` is `-1`', () => {
+      it('doesn\'t include an `offset` property', () => {
+        let node = new XmlNode();
+        assert.strictEqual(node.toJSON().offset, undefined);
+      });
+    });
+
+    describe('when `offset` is greater than -1', () => {
+      it('includes an `offset` property', () => {
+        let node = new XmlNode();
+        node.offset = 0;
+        assert.strictEqual(node.toJSON().offset, 0);
+      });
+    });
+  });
+
   describe('type', () => {
     it('is an empty string', () => {
       let node = new XmlNode();

--- a/tests/lib/XmlNode.test.js
+++ b/tests/lib/XmlNode.test.js
@@ -16,18 +16,23 @@ describe('XmlNode', () => {
   });
 
   describe('toJSON()', () => {
-    describe('when `offset` is `-1`', () => {
-      it('doesn\'t include an `offset` property', () => {
-        let node = new XmlNode();
-        assert.strictEqual(node.toJSON().offset, undefined);
+    describe('when `start` is `-1`', () => {
+      it('doesn\'t include the `start` or `end` properties', () => {
+        let json = new XmlNode().toJSON();
+        assert.strictEqual(json.start, undefined);
+        assert.strictEqual(json.end, undefined);
       });
     });
 
-    describe('when `offset` is greater than -1', () => {
-      it('includes an `offset` property', () => {
+    describe('when `start` is greater than -1', () => {
+      it('includes the `start` and `end` properties', () => {
         let node = new XmlNode();
-        node.offset = 0;
-        assert.strictEqual(node.toJSON().offset, 0);
+        node.start = 0;
+        node.end = 3;
+
+        let json = node.toJSON();
+        assert.strictEqual(json.start, 0);
+        assert.strictEqual(json.end, 3);
       });
     });
   });

--- a/tests/lib/XmlProcessingInstruction.test.js
+++ b/tests/lib/XmlProcessingInstruction.test.js
@@ -30,18 +30,34 @@ describe('XmlProcessingInstruction', () => {
     });
   });
 
-  describe('offset', () => {
-    describe('when `options.includeOffsets` is `false`', () => {
+  describe('when `options.includeOffsets` is `false`', () => {
+    describe('start', () => {
       it('is `-1`', () => {
         let { root } = parseXml('<root><?foo?></root>');
-        assert.strictEqual(root.children[0].offset, -1);
+        assert.strictEqual(root.children[0].start, -1);
       });
     });
 
-    describe('when `options.includeOffsets` is `true`', () => {
-      it('is the byte offset of the processing instruction', () => {
+    describe('end', () => {
+      it('is `-1`', () => {
+        let { root } = parseXml('<root><?foo?></root>');
+        assert.strictEqual(root.children[0].end, -1);
+      });
+    });
+  });
+
+  describe('when `options.includeOffsets` is `true`', () => {
+    describe('start', () => {
+      it('is the starting byte offset of the processing instruction', () => {
         let { root } = parseXml('<root><?foo?></root>', { includeOffsets: true });
-        assert.strictEqual(root.children[0].offset, 6);
+        assert.strictEqual(root.children[0].start, 6);
+      });
+    });
+
+    describe('end', () => {
+      it('is the ending byte offset of the processing instruction', () => {
+        let { root } = parseXml('<root><?foo?></root>', { includeOffsets: true });
+        assert.strictEqual(root.children[0].end, 13);
       });
     });
   });

--- a/tests/lib/XmlProcessingInstruction.test.js
+++ b/tests/lib/XmlProcessingInstruction.test.js
@@ -30,6 +30,22 @@ describe('XmlProcessingInstruction', () => {
     });
   });
 
+  describe('offset', () => {
+    describe('when `options.includeOffsets` is `false`', () => {
+      it('is `-1`', () => {
+        let { root } = parseXml('<root><?foo?></root>');
+        assert.strictEqual(root.children[0].offset, -1);
+      });
+    });
+
+    describe('when `options.includeOffsets` is `true`', () => {
+      it('is the byte offset of the processing instruction', () => {
+        let { root } = parseXml('<root><?foo?></root>', { includeOffsets: true });
+        assert.strictEqual(root.children[0].offset, 6);
+      });
+    });
+  });
+
   describe('parent', () => {
     it('is the parent element', () => {
       let { root } = parseXml('<root><?foo?></root>');

--- a/tests/lib/XmlText.test.js
+++ b/tests/lib/XmlText.test.js
@@ -23,18 +23,39 @@ describe('XmlText', () => {
     });
   });
 
-  describe('offset', () => {
-    describe('when `options.includeOffsets` is `false`', () => {
+  describe('when `options.includeOffsets` is `false`', () => {
+    describe('start', () => {
       it('is `-1`', () => {
         let { root } = parseXml('<root> foo &amp; bar\r\nbaz </root>');
-        assert.strictEqual(root.children[0].offset, -1);
+        assert.strictEqual(root.children[0].start, -1);
       });
     });
 
-    describe('when `options.includeOffsets` is `true`', () => {
-      it('is the byte offset of the text node', () => {
+    describe('end', () => {
+      it('is `-1`', () => {
+        let { root } = parseXml('<root> foo &amp; bar\r\nbaz </root>');
+        assert.strictEqual(root.children[0].end, -1);
+      });
+    });
+  });
+
+  describe('when `options.includeOffsets` is `true`', () => {
+    describe('start', () => {
+      it('is the starting byte offset of the text node', () => {
         let { root } = parseXml('<root> foo </root>', { includeOffsets: true });
-        assert.strictEqual(root.children[0].offset, 6);
+        assert.strictEqual(root.children[0].start, 6);
+      });
+    });
+
+    describe('end', () => {
+      it('is the ending byte offset of the text node', () => {
+        let { root } = parseXml('<root> foo </root>', { includeOffsets: true });
+        assert.strictEqual(root.children[0].end, 11);
+      });
+
+      it('is correct after multiple text nodes have been merged', () => {
+        let { root } = parseXml('<root>one&amp;two<!-- comment -->three</root>', { includeOffsets: true });
+        assert.strictEqual(root.children[0].end, 38);
       });
     });
   });

--- a/tests/lib/XmlText.test.js
+++ b/tests/lib/XmlText.test.js
@@ -23,6 +23,22 @@ describe('XmlText', () => {
     });
   });
 
+  describe('offset', () => {
+    describe('when `options.includeOffsets` is `false`', () => {
+      it('is `-1`', () => {
+        let { root } = parseXml('<root> foo &amp; bar\r\nbaz </root>');
+        assert.strictEqual(root.children[0].offset, -1);
+      });
+    });
+
+    describe('when `options.includeOffsets` is `true`', () => {
+      it('is the byte offset of the text node', () => {
+        let { root } = parseXml('<root> foo </root>', { includeOffsets: true });
+        assert.strictEqual(root.children[0].offset, 6);
+      });
+    });
+  });
+
   describe('text', () => {
     it('is the text content of the text node', () => {
       let { root } = parseXml('<root> foo &amp;  bar\r\nbaz </root>');


### PR DESCRIPTION
This adds a new parser option named `includeOffsets`, which defaults to `false`. When `includeOffsets` is `true`, the starting and ending byte offsets of each node in the input string will be made available via `start` and `end` properties on the node.

Closes #24