### PR TITLE
Add a new `preserveXmlDeclaration` parser option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,22 @@ All notable changes to parse-xml are documented in this file. The format is base
     // => { type: 'element', name: 'child', start: 6, end: 15, ... }
     ```
 
+-   Added a new `preserveXmlDeclaration` parser option.
+
+    When `true`, an `XmlDeclaration` node representing the XML declaration (if there is one) will be included in the parsed document. When `false`, the XML declaration will be discarded. The default is `false`, which matches the behavior of previous versions.
+
+    This option is useful if you want to preserve the XML declaration when later serializing a document back to XML. Previously, the XML declaration was always discarded, which meant that if you parsed a document with an XML declaration and then serialized it, the original XML declaration would be lost.
+
+    ```js
+    const { parseXml } = require('@rgrove/parse-xml');
+
+    let xml = '<?xml version="1.0" encoding="UTF-8"?><root />';
+    let doc = parseXml(xml, { preserveXmlDeclaration: true });
+
+    console.log(doc.children[0].toJSON());
+    // => { type: 'xmldecl', version: '1.0', encoding: 'UTF-8' }
+    ```
+
 ## 4.0.1 (2022-10-17)
 
 ### Fixed

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import type { ParserOptions } from './lib/Parser.js';
 export * from './lib/types.js';
 export { XmlCdata } from './lib/XmlCdata.js';
 export { XmlComment } from './lib/XmlComment.js';
+export { XmlDeclaration } from './lib/XmlDeclaration.js';
 export { XmlDocument } from './lib/XmlDocument.js';
 export { XmlElement } from './lib/XmlElement.js';
 export { XmlNode } from './lib/XmlNode.js';

--- a/src/lib/XmlDeclaration.ts
+++ b/src/lib/XmlDeclaration.ts
@@ -1,0 +1,61 @@
+import { XmlNode } from './XmlNode.js';
+
+/**
+ * An XML declaration within an XML document.
+ *
+ * @example
+ *
+ * ```xml
+ * <?xml version="1.0" encoding="UTF-8"?>
+ * ```
+ */
+export class XmlDeclaration extends XmlNode {
+  /**
+   * Value of the encoding declaration in this XML declaration, or `null` if no
+   * encoding declaration was present.
+   */
+  encoding: string | null;
+
+  /**
+   * Value of the standalone declaration in this XML declaration, or `null` if
+   * no standalone declaration was present.
+   */
+  standalone: string | null;
+
+  /**
+   * Value of the version declaration in this XML declaration.
+   */
+  version: string;
+
+  constructor(
+    version: string,
+    encoding: string | null = null,
+    standalone: string | null = null,
+  ) {
+    super();
+
+    this.version = version;
+    this.encoding = encoding;
+    this.standalone = standalone;
+  }
+
+  override get type() {
+    return XmlNode.TYPE_XML_DECLARATION;
+  }
+
+  override toJSON() {
+    let json = XmlNode.prototype.toJSON.call(this);
+
+    json.version = this.version;
+
+    if (this.encoding !== null) {
+      json.encoding = this.encoding;
+    }
+
+    if (this.standalone !== null) {
+      json.standalone = this.standalone;
+    }
+
+    return json;
+  }
+}

--- a/src/lib/XmlDocument.ts
+++ b/src/lib/XmlDocument.ts
@@ -2,6 +2,7 @@ import { XmlElement } from './XmlElement.js';
 import { XmlNode } from './XmlNode.js';
 
 import type { XmlComment } from './XmlComment.js';
+import type { XmlDeclaration } from './XmlDeclaration.js';
 import type { XmlProcessingInstruction } from './XmlProcessingInstruction.js';
 
 /**
@@ -12,9 +13,9 @@ export class XmlDocument extends XmlNode {
   /**
    * Child nodes of this document.
    */
-  readonly children: Array<XmlComment | XmlProcessingInstruction | XmlElement>;
+  readonly children: Array<XmlComment | XmlDeclaration | XmlProcessingInstruction | XmlElement>;
 
-  constructor(children: Array<XmlComment | XmlElement | XmlProcessingInstruction> = []) {
+  constructor(children: Array<XmlComment | XmlDeclaration | XmlElement | XmlProcessingInstruction> = []) {
     super();
     this.children = children;
   }

--- a/src/lib/XmlNode.ts
+++ b/src/lib/XmlNode.ts
@@ -37,6 +37,11 @@ export class XmlNode {
   static readonly TYPE_TEXT = 'text';
 
   /**
+   * Type value for an `XmlDeclaration` node.
+   */
+  static readonly TYPE_XML_DECLARATION = 'xmldecl';
+
+  /**
    * Parent node of this node, or `null` if this node has no parent.
    */
   parent: XmlDocument | XmlElement | null = null;
@@ -62,10 +67,13 @@ export class XmlNode {
   }
 
   /**
-   * Whether this node is the root node of the document.
+   * Whether this node is the root node of the document (also known as the
+   * document element).
    */
   get isRootNode(): boolean {
-    return this.parent !== null && this.parent === this.document;
+    return this.parent !== null
+      && this.parent === this.document
+      && this.type === XmlNode.TYPE_ELEMENT;
   }
 
   /**

--- a/tests/browser/browserTests.js
+++ b/tests/browser/browserTests.js
@@ -5,6 +5,7 @@ require('../lib/Parser.test.js');
 require('../lib/StringScanner.test.js');
 require('../lib/XmlCdata.test.js');
 require('../lib/XmlComment.test.js');
+require('../lib/XmlDeclaration.test.js');
 require('../lib/XmlDocument.test.js');
 require('../lib/XmlElement.test.js');
 require('../lib/XmlNode.test.js');

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -3,11 +3,12 @@
 
 const assert = require('assert');
 
-const { parseXml, XmlCdata, XmlComment, XmlDocument, XmlElement, XmlNode, XmlProcessingInstruction, XmlText } = require('..');
+const { parseXml, XmlCdata, XmlComment, XmlDeclaration, XmlDocument, XmlElement, XmlNode, XmlProcessingInstruction, XmlText } = require('..');
 
 it('exports XML node classes', () => {
   assert.equal(typeof XmlCdata, 'function');
   assert.equal(typeof XmlComment, 'function');
+  assert.equal(typeof XmlDeclaration, 'function');
   assert.equal(typeof XmlDocument, 'function');
   assert.equal(typeof XmlElement, 'function');
   assert.equal(typeof XmlNode, 'function');

--- a/tests/lib/XmlDeclaration.test.js
+++ b/tests/lib/XmlDeclaration.test.js
@@ -1,0 +1,142 @@
+/* eslint-env mocha */
+'use strict';
+
+const assert = require('assert');
+
+const { parseXml, XmlDeclaration, XmlNode } = require('../..');
+
+describe('XmlDeclaration', () => {
+  let xml;
+
+  beforeEach(() => {
+    xml = `<?xml version="1.0"?><root />`;
+  });
+
+  it("isn't emitted by default", () => {
+    let doc = parseXml(xml);
+    assert.strictEqual(doc.children.length, 1);
+    assert.strictEqual(doc.children[0].type, XmlNode.TYPE_ELEMENT);
+  });
+
+  it('is emitted when `options.preserveXmlDeclaration` is `true`', () => {
+    let [ node ] = parseXml(xml, { preserveXmlDeclaration: true }).children;
+    assert(node instanceof XmlDeclaration);
+  });
+
+  it('may be instantiated without `encoding` or `standalone` arguments', () => {
+    let node = new XmlDeclaration('1.0');
+    assert.strictEqual(node.version, '1.0');
+    assert.strictEqual(node.encoding, null);
+    assert.strictEqual(node.standalone, null);
+  });
+
+  describe('encoding', () => {
+    describe('when no encoding is specified', () => {
+      it('is `null`', () => {
+        let [ node ] = parseXml(xml, { preserveXmlDeclaration: true }).children;
+        assert.strictEqual(node.encoding, null);
+      });
+    });
+
+    describe('when an encoding is specified', () => {
+      beforeEach(() => {
+        xml = `<?xml version="1.0" encoding="UTF-8"?><root />`;
+      });
+
+      it('is the encoding of the XML declaration', () => {
+        let [ node ] = parseXml(xml, { preserveXmlDeclaration: true }).children;
+        assert.strictEqual(node.encoding, 'UTF-8');
+      });
+    });
+  });
+
+  describe('standalone', () => {
+    describe('when not specified', () => {
+      it('is `null`', () => {
+        let [ node ] = parseXml(xml, { preserveXmlDeclaration: true }).children;
+        assert.strictEqual(node.standalone, null);
+      });
+    });
+
+    describe('when specified', () => {
+      beforeEach(() => {
+        xml = `<?xml version="1.0" standalone="yes"?><root />`;
+      });
+
+      it('is the value of the standalone declaration', () => {
+        let [ node ] = parseXml(xml, { preserveXmlDeclaration: true }).children;
+        assert.strictEqual(node.standalone, 'yes');
+      });
+    });
+  });
+
+  describe('toJSON()', () => {
+    it('returns a serializable object representation of the XML declaration', () => {
+      let [ node ] = parseXml(xml, { preserveXmlDeclaration: true }).children;
+
+      assert.deepStrictEqual(node.toJSON(), {
+        type: XmlNode.TYPE_XML_DECLARATION,
+        version: '1.0',
+      });
+    });
+
+    it('includes `encoding` and `standalone` when specified', () => {
+      xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><root />`;
+
+      let [ node ] = parseXml(xml, { preserveXmlDeclaration: true }).children;
+
+      assert.deepStrictEqual(node.toJSON(), {
+        type: XmlNode.TYPE_XML_DECLARATION,
+        version: '1.0',
+        encoding: 'UTF-8',
+        standalone: 'yes',
+      });
+    });
+  });
+
+  describe('type', () => {
+    it('is `XmlNode.TYPE_XML_DECLARATION`', () => {
+      let [ node ] = parseXml(xml, { preserveXmlDeclaration: true }).children;
+      assert.strictEqual(node.type, XmlNode.TYPE_XML_DECLARATION);
+    });
+  });
+
+  describe('version', () => {
+    it('is the version of the XML declaration', () => {
+      let [ node ] = parseXml(xml, { preserveXmlDeclaration: true }).children;
+      assert.strictEqual(node.version, '1.0');
+    });
+  });
+
+  describe('when `options.includeOffsets` is `false`', () => {
+    describe('start', () => {
+      it('is `-1`', () => {
+        let [ node ] = parseXml(xml, { preserveXmlDeclaration: true }).children;
+        assert.strictEqual(node.start, -1);
+      });
+    });
+
+    describe('end', () => {
+      it('is `-1`', () => {
+        let [ node ] = parseXml(xml, { preserveXmlDeclaration: true }).children;
+        assert.strictEqual(node.end, -1);
+      });
+    });
+  });
+
+  describe('when `options.includeOffsets` is `true`', () => {
+    describe('start', () => {
+      it('is the starting byte offset of the XML declaration', () => {
+        let [ node ] = parseXml(xml, { includeOffsets: true, preserveXmlDeclaration: true }).children;
+        assert.strictEqual(node.start, 0);
+      });
+    });
+
+    describe('end', () => {
+      it('is the ending byte offset of the XML declaration', () => {
+        let [ node ] = parseXml(xml, { includeOffsets: true, preserveXmlDeclaration: true }).children;
+        assert.strictEqual(node.end, 21);
+      });
+    });
+  });
+});


### PR DESCRIPTION
When `true`, an `XmlDeclaration` node representing the XML declaration (if there is one) will be included in the parsed document. When `false`, the XML declaration will be discarded. The default is `false`, which matches the behavior of previous versions.

This option is useful if you want to preserve the XML declaration when later serializing a document back to XML. Previously, the XML declaration was always discarded, which meant that if you parsed a document with an XML declaration and then serialized it, the original XML declaration would be lost.

```js
const { parseXml } = require('@rgrove/parse-xml');

let xml = '<?xml version="1.0" encoding="UTF-8"?><root />';
let doc = parseXml(xml, { preserveXmlDeclaration: true });

console.log(doc.children[0].toJSON());
// => { type: 'xmldecl', version: '1.0', encoding: 'UTF-8' }
```

This is the first half of #30.

/cc @wooorm