### PR TITLE
Add a new `preserveDocumentType` parser option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,34 @@ All notable changes to parse-xml are documented in this file. The format is base
     // => { type: 'xmldecl', version: '1.0', encoding: 'UTF-8' }
     ```
 
+-   Added a new `preserveDocumentType` parser option.
+
+    When `true`, an `XmlDocumentType` node representing a document type declaration (if there is one) will be included in the parsed document. When `false`, any document type declaration encountered will be discarded. The default is `false`, which matches the behavior of previous versions.
+
+    Note that the parser only includes the document type declaration in the node tree; it doesn't actually validate the document against the DTD, load external DTDs, or resolve custom entity references.
+
+    This option is useful if you want to preserve the document type declaration when later serializing a document back to XML. Previously, the document type declaration was always discarded, which meant that if you parsed a document with a document type declaration and then serialized it, the original document type declaration would be lost.
+
+    ```js
+    const { parseXml } = require('@rgrove/parse-xml');
+
+    let xml = '<!DOCTYPE root SYSTEM "root.dtd"><root />';
+    let doc = parseXml(xml, { preserveDocumentType: true });
+
+    console.log(doc.children[0].toJSON());
+    // => { type: 'doctype', name: 'root', systemId: 'root.dtd' }
+
+    xml = '<!DOCTYPE kittens [<!ELEMENT kittens (#PCDATA)>]><kittens />';
+    doc = parseXml(xml, { preserveDocumentType: true });
+
+    console.log(doc.children[0].toJSON());
+    // => {
+    //   type: 'doctype',
+    //   name: 'kittens',
+    //   internalSubset: '<!ELEMENT kittens (#PCDATA)>'
+    // }
+    ```
+
 ## 4.0.1 (2022-10-17)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Or, if you like living dangerously, you can load [the minified bundle](https://u
 
 ## Not Features
 
-This parser currently discards document type declarations (`<!DOCTYPE ... >`) and all their contents, because they're rarely useful and some of their features aren't safe when the XML being parsed comes from an untrusted source.
+While this parser is capable of parsing document type declarations (`<!DOCTYPE ... >`) and including them in the node tree, it doesn't actually do anything with them. External document type definitions won't be loaded, and the parser won't validate the document against a DTD or resolve custom entity references defined in a DTD.
 
 In addition, the only supported character encoding is UTF-8 because it's not feasible (or useful) to support other character encodings in JavaScript.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export { XmlCdata } from './lib/XmlCdata.js';
 export { XmlComment } from './lib/XmlComment.js';
 export { XmlDeclaration } from './lib/XmlDeclaration.js';
 export { XmlDocument } from './lib/XmlDocument.js';
+export { XmlDocumentType } from './lib/XmlDocumentType.js';
 export { XmlElement } from './lib/XmlElement.js';
 export { XmlNode } from './lib/XmlNode.js';
 export { XmlProcessingInstruction } from './lib/XmlProcessingInstruction.js';

--- a/src/lib/XmlDocumentType.ts
+++ b/src/lib/XmlDocumentType.ts
@@ -1,0 +1,67 @@
+import { XmlNode } from './XmlNode.js';
+
+/**
+ * A document type declaration within an XML document.
+ *
+ * @example
+ *
+ * ```xml
+ * <!DOCTYPE kittens [
+ *   <!ELEMENT kittens (#PCDATA)>
+ * ]>
+ * ```
+ */
+export class XmlDocumentType extends XmlNode {
+  /**
+   * Name of the root element described by this document type declaration.
+   */
+  name: string;
+
+  /**
+   * Public identifier of the external subset of this document type declaration,
+   * or `null` if no public identifier was present.
+   */
+  publicId: string | null;
+
+  /**
+   * System identifier of the external subset of this document type declaration,
+   * or `null` if no system identifier was present.
+   */
+  systemId: string | null;
+
+  /**
+   * Internal subset of this document type declaration, or `null` if no internal
+   * subset was present.
+   */
+  internalSubset: string | null;
+
+  constructor(
+    name: string,
+    publicId?: string,
+    systemId?: string,
+    internalSubset?: string,
+  ) {
+    super();
+    this.name = name;
+    this.publicId = publicId ?? null;
+    this.systemId = systemId ?? null;
+    this.internalSubset = internalSubset ?? null;
+  }
+
+  override get type() {
+    return XmlNode.TYPE_DOCUMENT_TYPE;
+  }
+
+  override toJSON() {
+    let json = XmlNode.prototype.toJSON.call(this);
+    json.name = this.name;
+
+    for (let key of ['publicId', 'systemId', 'internalSubset'] as const) {
+      if (this[key] !== null) {
+        json[key] = this[key];
+      }
+    }
+
+    return json;
+  }
+}

--- a/src/lib/XmlNode.ts
+++ b/src/lib/XmlNode.ts
@@ -22,6 +22,11 @@ export class XmlNode {
   static readonly TYPE_DOCUMENT = 'document';
 
   /**
+   * Type value for an `XmlDocumentType` node.
+   */
+  static readonly TYPE_DOCUMENT_TYPE = 'doctype';
+
+  /**
    * Type value for an `XmlElement` node.
    */
   static readonly TYPE_ELEMENT = 'element';

--- a/tests/browser/browserTests.js
+++ b/tests/browser/browserTests.js
@@ -7,6 +7,7 @@ require('../lib/XmlCdata.test.js');
 require('../lib/XmlComment.test.js');
 require('../lib/XmlDeclaration.test.js');
 require('../lib/XmlDocument.test.js');
+require('../lib/XmlDocumentType.test.js');
 require('../lib/XmlElement.test.js');
 require('../lib/XmlNode.test.js');
 require('../lib/XmlProcessingInstruction.test.js');

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -3,13 +3,14 @@
 
 const assert = require('assert');
 
-const { parseXml, XmlCdata, XmlComment, XmlDeclaration, XmlDocument, XmlElement, XmlNode, XmlProcessingInstruction, XmlText } = require('..');
+const { parseXml, XmlCdata, XmlComment, XmlDeclaration, XmlDocument, XmlDocumentType, XmlElement, XmlNode, XmlProcessingInstruction, XmlText } = require('..');
 
 it('exports XML node classes', () => {
   assert.equal(typeof XmlCdata, 'function');
   assert.equal(typeof XmlComment, 'function');
   assert.equal(typeof XmlDeclaration, 'function');
   assert.equal(typeof XmlDocument, 'function');
+  assert.equal(typeof XmlDocumentType, 'function');
   assert.equal(typeof XmlElement, 'function');
   assert.equal(typeof XmlNode, 'function');
   assert.equal(typeof XmlProcessingInstruction, 'function');

--- a/tests/lib/XmlDocumentType.test.js
+++ b/tests/lib/XmlDocumentType.test.js
@@ -1,0 +1,101 @@
+/* eslint-env mocha */
+'use strict';
+
+const assert = require('assert');
+
+const { parseXml, XmlDocumentType, XmlNode } = require('../..');
+
+describe('XmlDocumentType', () => {
+  let xml;
+
+  beforeEach(() => {
+    xml = `
+      <!DOCTYPE kittens>
+      <kittens />
+    `;
+  });
+
+  it("isn't emitted by default", () => {
+    let doc = parseXml(xml);
+    assert.strictEqual(doc.children.length, 1);
+    assert.strictEqual(doc.children[0].type, XmlNode.TYPE_ELEMENT);
+  });
+
+  it('is emitted when `options.preserveDocumentType` is `true`', () => {
+    let [ node ] = parseXml(xml, { preserveDocumentType: true }).children;
+    assert(node instanceof XmlDocumentType);
+  });
+
+  describe('toJSON()', () => {
+    it('returns a serializable object representation of the document type', () => {
+      let [ node ] = parseXml(xml, { preserveDocumentType: true }).children;
+
+      assert.deepStrictEqual(node.toJSON(), {
+        type: XmlNode.TYPE_DOCUMENT_TYPE,
+        name: 'kittens',
+      });
+    });
+
+    it("includes `publicId`,  `systemId`, and `internalSubset` when they aren't null", () => {
+      xml = `
+        <!DOCTYPE kittens PUBLIC "kittens!" "kittens.dtd" [
+          <!ELEMENT kittens (#PCDATA)>
+        ]>
+        <kittens />
+      `;
+
+      // Find the initial indentation of the doctype so we can match it in the
+      // assertion.
+      let indent = xml.match(/^\n*(\s*)/, '$1')[1];
+
+      let [ node ] = parseXml(xml, { preserveDocumentType: true }).children;
+
+      assert.deepStrictEqual(node.toJSON(), {
+        type: XmlNode.TYPE_DOCUMENT_TYPE,
+        name: 'kittens',
+        publicId: 'kittens!',
+        systemId: 'kittens.dtd',
+        internalSubset: `\n${indent}  <!ELEMENT kittens (#PCDATA)>\n${indent}`,
+      });
+    });
+  });
+
+  describe('type', () => {
+    it('is `XmlNode.TYPE_DOCUMENT_TYPE`', () => {
+      let [ node ] = parseXml(xml, { preserveDocumentType: true }).children;
+      assert.strictEqual(node.type, XmlNode.TYPE_DOCUMENT_TYPE);
+    });
+  });
+
+  describe('when `options.includeOffsets` is `false`', () => {
+    describe('start', () => {
+      it('is `-1`', () => {
+        let [ node ] = parseXml(xml, { preserveDocumentType: true }).children;
+        assert.strictEqual(node.start, -1);
+      });
+    });
+
+    describe('end', () => {
+      it('is `-1`', () => {
+        let [ node ] = parseXml(xml, { preserveDocumentType: true }).children;
+        assert.strictEqual(node.end, -1);
+      });
+    });
+  });
+
+  describe('when `options.includeOffsets` is `true`', () => {
+    describe('start', () => {
+      it('is the starting byte offset of the document type', () => {
+        let [ node ] = parseXml(xml, { includeOffsets: true, preserveDocumentType: true }).children;
+        assert.strictEqual(node.start, 7);
+      });
+    });
+
+    describe('end', () => {
+      it('is the ending byte offset of the document type', () => {
+        let [ node ] = parseXml(xml, { includeOffsets: true, preserveDocumentType: true }).children;
+        assert.strictEqual(node.end, 25);
+      });
+    });
+  });
+});


### PR DESCRIPTION
When `true`, an `XmlDocumentType` node representing a document type declaration (if there is one) will be included in the parsed document. When `false`, any document type declaration encountered will be discarded. The default is `false`, which matches the behavior of previous versions.

Note that the parser only includes the document type declaration in the node tree; it doesn't actually validate the document against the DTD, load external DTDs, or resolve custom entity references.

This option is useful if you want to preserve the document type declaration when later serializing a document back to XML. Previously, the document type declaration was always discarded, which meant that if you parsed a document with a document type declaration and then serialized it, the original document type declaration would be lost.

```js
const { parseXml } = require('@rgrove/parse-xml');

let xml = '<!DOCTYPE root SYSTEM "root.dtd"><root />';
let doc = parseXml(xml, { preserveDocumentType: true });

console.log(doc.children[0].toJSON());
// => { type: 'doctype', name: 'root', systemId: 'root.dtd' }

xml = '<!DOCTYPE kittens [<!ELEMENT kittens (#PCDATA)>]><kittens />';
doc = parseXml(xml, { preserveDocumentType: true });

console.log(doc.children[0].toJSON());
// => {
//   type: 'doctype',
//   name: 'kittens',
//   internalSubset: '<!ELEMENT kittens (#PCDATA)>'
// }
```

/cc @wooorm