### PR TITLE
split the eror-raising part of constructor into separate method.

### DIFF
--- a/src/lib/Parser.ts
+++ b/src/lib/Parser.ts
@@ -31,7 +31,7 @@ export class Parser {
    */
   constructor(xml: string, options: ParserOptions = {}) {
     let doc = this.document = new XmlDocument();
-    let scanner = this.scanner = new StringScanner(xml);
+    this.scanner = new StringScanner(xml);
 
     this.currentNode = doc;
     this.options = options;
@@ -40,8 +40,12 @@ export class Parser {
       doc.start = 0;
       doc.end = xml.length;
     }
+    
+    this.startParse();
+  }
 
-    scanner.consumeStringFast('\uFEFF'); // byte order mark
+  startParse() {
+    this.scanner.consumeStringFast('\uFEFF'); // byte order mark
     this.consumeProlog();
 
     if (!this.consumeElement()) {
@@ -50,7 +54,7 @@ export class Parser {
 
     while (this.consumeMisc()) {} // eslint-disable-line no-empty
 
-    if (!scanner.isEnd) {
+    if (!this.scanner.isEnd) {
       throw this.error('Extra content at the end of the document');
     }
   }


### PR DESCRIPTION
Hi !
I found this lib is quite good, but I face a trouble while inherit the Parser class.

My situation is: I want to parse a section of xml (a string, not a whole file), hence it may has several root elements.
Now I want my (inheritance) parser to keep parsing for second root and so.
Ideally, it would be like as:
```typescript
class MyParser extends Parser {
    //? Allow multiroot
    constructor(xml: string, options: ParserOptions = {}) {
        try {
            super(xml, options);
        } catch (err) {
            // we do not care about multiroot validation here
            if(!(err as Error).message.startsWith('Extra content at the end of the document'))
                throw err; // show non multi-root error
        
            while (!this.scanner.isEnd) {
                this.consumeElement();
                this.consumeMisc();
            }
        }
    }
```
But that code is invalid; bacause `super()` can't be called inside `try..catch`.

Currently, I solve it by copying the whole class and modify the constructor; and yes it works, but it isn't what I want to do.
Modifying some methods (as needed) is the best practice, I think.

So, here the patch to allow the parser to be inherited (especially to not throwing error on constructor).

note: 
* I am sorry for my bad english I wish you okay.
* I also pass the tests, and its fine too.
* here a picture below: multi root xml usage in real life (my VS Code notebook [project](https://github.com/x2nie/MarkovJuniorWeb/tree/x2nie-yup-book)). 

![image](https://github.com/user-attachments/assets/3238d1a4-71c1-44ac-8598-94db523a644e)

