### PR TITLE
feat: Add allowFullCodepoints option to allow support for full codepoint

### DIFF
--- a/src/lib/Parser.ts
+++ b/src/lib/Parser.ts
@@ -606,7 +606,7 @@ export class Parser {
         throw this.error('Invalid character reference');
       }
 
-      if (!syntax.isXmlCodePoint(codePoint)) {
+      if (!syntax.isXmlCodePoint(codePoint) && !this.options.allowFullCodepoints) {
         throw this.error('Character reference resolves to an invalid character');
       }
 
@@ -834,6 +834,14 @@ export type ParserOptions = {
    * @default false
    */
   ignoreUndefinedEntities?: boolean;
+
+  /**
+   * When `true`, an invalid entity codepoint (like "&#27;") will be converted
+   * to a character instead of causing a parse error.
+   *
+   * @default false
+   */
+  allowFullCodepoints?: boolean;
 
   /**
    * When `true`, the starting and ending byte offsets of each node in the input

--- a/tests/lib/Parser.test.js
+++ b/tests/lib/Parser.test.js
@@ -60,6 +60,18 @@ describe('Parser', () => {
     });
   });
 
+  describe('when `options.allowFullCodepoints` is `true`', () => {
+    beforeEach(() => {
+      options.allowFullCodepoints = true;
+    });
+
+    it('converts invalid codepoints to it\'s character equivalent', () => {
+      let { root } = parseXml('<root foo="bar &#27; baz">&#28;</root>', options);
+      assert.strictEqual(root.attributes.foo, 'bar \x1b baz');
+      assert.strictEqual(root.text, '\x1c');
+    });
+  });
+
   describe('when `options.includeOffsets` is `true`', () => {
     it('the start offset is a byte offset, not a character offset', () => {
       let { root } = parseXml('<root><cat>🐈</cat><dog>🐕</dog></root>', { includeOffsets: true });

--- a/tests/types.expect.ts
+++ b/tests/types.expect.ts
@@ -12,6 +12,7 @@ expectTypeOf(parseXml).returns.toEqualTypeOf<XmlDocument>();
 
 // -- ParserOptions ------------------------------------------------------------
 expectTypeOf<ParserOptions>().toHaveProperty('ignoreUndefinedEntities').toEqualTypeOf<boolean | undefined>();
+expectTypeOf<ParserOptions>().toHaveProperty('allowFullCodepoints').toEqualTypeOf<boolean | undefined>();
 expectTypeOf<ParserOptions>().toHaveProperty('includeOffsets').toEqualTypeOf<boolean | undefined>();
 expectTypeOf<ParserOptions>().toHaveProperty('preserveCdata').toEqualTypeOf<boolean | undefined>();
 expectTypeOf<ParserOptions>().toHaveProperty('preserveComments').toEqualTypeOf<boolean | undefined>();


### PR DESCRIPTION
This feature adds support for using full codepoints. It ignores the XML valid codepoints entirely and allows you use character references like `&#27;` (it's `0x1B` btw)

This way we can embed special characters inside XML.