### PR TITLE
fix: do not line-end-normalize a CR character reference in content

### DIFF
--- a/src/lib/Parser.ts
+++ b/src/lib/Parser.ts
@@ -65,12 +65,19 @@ export class Parser {
   /**
    * Adds the given _text_ to the document, either by appending it to a
    * preceding `XmlText` node (if possible) or by creating a new `XmlText` node.
+   *
+   * When _normalize_ is `true` (the default), line breaks in _text_ are
+   * normalized per section 2.11 of the XML spec. This must be `false` for text
+   * that comes from a character or entity reference, since references aren't
+   * subject to line break normalization.
    */
-  addText(text: string, charIndex: number) {
+  addText(text: string, charIndex: number, normalize = true) {
     let { children } = this.currentNode;
     let { length } = children;
 
-    text = normalizeLineBreaks(text);
+    if (normalize) {
+      text = normalizeLineBreaks(text);
+    }
 
     if (length > 0) {
       let prevNode = children[length - 1];
@@ -297,7 +304,7 @@ export class Parser {
     let ref = this.consumeReference();
 
     return ref
-      ? this.addText(ref, startIndex)
+      ? this.addText(ref, startIndex, false)
       : false;
   }
 

--- a/tests/lib/Parser.test.js
+++ b/tests/lib/Parser.test.js
@@ -390,6 +390,24 @@ describe('Parser', () => {
       assert.strictEqual(root.attributes.d, " a   z ");
     });
 
+    // A character reference for a carriage return (`&#xD;` / `&#13;`) in content
+    // must be preserved as a literal `\r`. Line break normalization only applies
+    // to literal line breaks in the input, not to characters that come from a
+    // character reference.
+    // https://www.w3.org/TR/2008/REC-xml-20081126/#sec-line-ends
+    // https://www.w3.org/TR/2008/REC-xml-20081126/#entproc
+    it("doesn't normalize a character reference for a carriage return in content", () => {
+      assert.strictEqual(parseXml('<a>&#xD;</a>').root.children[0].text, '\r');
+      assert.strictEqual(parseXml('<a>&#13;</a>').root.children[0].text, '\r');
+
+      // A literal `\r` is normalized to `\n`, but a `&#xD;` reference following
+      // it must remain a `\r`.
+      assert.strictEqual(parseXml('<a>x\r&#xD;y</a>').root.children[0].text, 'x\n\ry');
+
+      // `&#xD;&#xA;` must remain `\r\n` rather than collapsing to `\n` or `\n\n`.
+      assert.strictEqual(parseXml('<a>&#xD;&#xA;</a>').root.children[0].text, '\r\n');
+    });
+
     it('handles many character references in a single attribute', () => {
       let { root } = parseXml('<a b="&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;"/>');
       assert.strictEqual(root.attributes.b, "<".repeat(35));


### PR DESCRIPTION
## Problem

A character reference resolving to a carriage return (`&#xD;` or `&#13;`) in element **text content** is wrongly converted to a line feed.

```js
parseXml('<a>&#xD;</a>').root.children[0].text // '\n'  (wrong)
// expected: '\r'
```

XML 1.0 section 2.11 end-of-line normalization applies **only to literal line breaks in the input**, not to characters produced by a character or entity reference (see sections 4.6 / 4.1). The reference must be passed through to the application as the literal character it denotes.

The cause: `consumeContentReference` routes the resolved reference text through `addText`, which unconditionally calls `normalizeLineBreaks`. So a resolved `&#xD;` is collapsed to `\n` just like a literal CR in the source would be.

## Evidence this is the intended behavior

- The vendored W3C conformance test `xmltest/valid/sa/067.xml` (`<doc>&#13;</doc>`) has canonical output `<doc>&#13;</doc>`, i.e. the CR must survive.
- The existing attribute-side test ("doesn't normalize a character reference for a whitespace character", issue #6) already asserts this for attributes. The content path was simply never tested, and the attribute path uses a different code route, so the bug stayed hidden.

## Fix

Add a `normalize` parameter to `addText` (default `true`) gating the `normalizeLineBreaks` call, and pass `false` from `consumeContentReference`. The CDATA and CharData callers keep the default `true`, since literal content **is** subject to section 2.11.

## Verification

- New test fails on `main` (`'\n' !== '\r'`) and passes with the fix.
- Full suite green (1378 passing, up from 1377), 100% coverage maintained.
- W3C conformance suite still green.

### References
- https://www.w3.org/TR/2008/REC-xml-20081126/#sec-line-ends
- https://www.w3.org/TR/2008/REC-xml-20081126/#entproc