### PR TITLE
fix: reject numeric character references with trailing non-digit characters

### DIFF
--- a/src/lib/Parser.ts
+++ b/src/lib/Parser.ts
@@ -609,7 +609,8 @@ export class Parser {
         ? parseInt(ref.slice(2), 16) // Hex codepoint.
         : parseInt(ref.slice(1), 10); // Decimal codepoint.
 
-      if (isNaN(codePoint)) {
+      if (isNaN(codePoint)
+          || !/^#(?:x[0-9A-Fa-f]+|[0-9]+)$/.test(ref)) {
         throw this.error('Invalid character reference');
       }
 

--- a/tests/lib/Parser.test.js
+++ b/tests/lib/Parser.test.js
@@ -408,6 +408,17 @@ describe('Parser', () => {
       assert.strictEqual(parseXml('<a>&#xD;&#xA;</a>').root.children[0].text, '\r\n');
     });
 
+    // A numeric character reference must consist solely of digits, so a
+    // reference like `&#65a;` or `&#x41g;` is malformed and must be rejected
+    // rather than silently truncated to the leading numeric portion.
+    // https://www.w3.org/TR/2008/REC-xml-20081126/#NT-CharRef
+    it('rejects a numeric character reference with trailing non-digit characters', () => {
+      assert.throws(() => parseXml('<a>&#65a;</a>'), /Invalid character reference/);
+      assert.throws(() => parseXml('<a>&#48f;</a>'), /Invalid character reference/);
+      assert.throws(() => parseXml('<a>&#x41g;</a>'), /Invalid character reference/);
+      assert.throws(() => parseXml('<a b="&#65z;" />'), /Invalid character reference/);
+    });
+
     it('handles many character references in a single attribute', () => {
       let { root } = parseXml('<a b="&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;"/>');
       assert.strictEqual(root.attributes.b, "<".repeat(35));


### PR DESCRIPTION
`parseXml('<a>&#65a;</a>')` returns the text `A` instead of throwing. A numeric character reference is validated with `parseInt()`, which stops at the first character that isn't a valid digit and returns whatever it parsed up to that point. So a malformed reference whose trailing `Name` characters aren't digits is silently accepted and resolved to its leading numeric portion:

- `&#65a;` -> `A`
- `&#48f;` -> `0`
- `&#x41g;` -> `A`
- `&#65z;` -> `A`

Per [`CharRef`](https://www.w3.org/TR/2008/REC-xml-20081126/#NT-CharRef) a character reference is `'&#' [0-9]+ ';'` or `'&#x' [0-9a-fA-F]+ ';'`, so each of these is a well-formedness error and should be rejected.

Fix validates the reference digits before resolving the code point. Valid decimal, hex (including uppercase and supplementary code points), and predefined entities are unaffected.

Adds a regression test.
