### PR TITLE
Don't reject a document that starts with a "<?xml…" processing instruction

### DIFF
--- a/src/lib/Parser.ts
+++ b/src/lib/Parser.ts
@@ -712,6 +712,15 @@ export class Parser {
       return false;
     }
 
+    // `<?xml` begins an XML declaration only when it's immediately followed by
+    // whitespace. If the next character is a name character, this is a
+    // processing instruction whose target merely begins with "xml" (e.g.
+    // `<?xml-stylesheet ... ?>`); rewind and let it be parsed as a PI.
+    if (syntax.isNameChar(scanner.peek())) {
+      scanner.reset(startIndex);
+      return false;
+    }
+
     if (!this.consumeWhitespace()) {
       throw this.error('Invalid XML declaration');
     }

--- a/tests/lib/Parser.test.js
+++ b/tests/lib/Parser.test.js
@@ -178,13 +178,13 @@ describe('Parser', () => {
     describe('invalid XML declaration', () => {
       it('throws an error', () => {
         assert.throws(() => {
-          parseXml('<?xmlblah');
+          parseXml('<?xml?>');
         }, {
           column: 6,
-          excerpt: '<?xmlblah',
+          excerpt: '<?xml?>',
           line: 1,
           message: 'Invalid XML declaration (line 1, column 6)\n' +
-            '  <?xmlblah\n' +
+            '  <?xml?>\n' +
             '       ^\n',
           pos: 5,
         });

--- a/tests/lib/XmlProcessingInstruction.test.js
+++ b/tests/lib/XmlProcessingInstruction.test.js
@@ -16,6 +16,13 @@ describe('XmlProcessingInstruction', () => {
     assert.strictEqual(JSON.stringify(root.children[0]), `{"type":"pi","name":"xml-stylesheet","content":"type=\\"text/xsl\\" href=\\"style.xsl\\""}`);
   });
 
+  it('may begin the document when its target starts with "xml"', () => {
+    let doc = parseXml('<?xml-stylesheet type="text/xsl" href="style.xsl"?><root/>');
+    assert(doc.children[0] instanceof XmlProcessingInstruction);
+    assert.strictEqual(doc.children[0].name, 'xml-stylesheet');
+    assert.strictEqual(doc.root.name, 'root');
+  });
+
   describe('constructor', () => {
     it('defaults the value of `content` to an empty string if not provided', () => {
       let pi = new XmlProcessingInstruction('foo');


### PR DESCRIPTION
### Problem

`consumeXmlDeclaration` matches the 5-character literal `<?xml` and then requires
whitespace, so a document that **begins** with a processing instruction whose
target merely starts with `xml` is forced down the XML-declaration path and
rejected:

```js
parseXml('<?xml-stylesheet type="text/xsl" href="a.xsl"?><a/>');
// throws: Invalid XML declaration (line 1, column 6)
parseXml('<?xml-model href="a.rng"?><a/>');
// throws: Invalid XML declaration (line 1, column 6)
```

These are well-formed documents, and both `<?xml-stylesheet?>` and `<?xml-model?>`
are extremely common in the wild (RSS/Atom, SVG, any XML+XSLT/CSS document). The
same PI parses fine when it isn't first:

```js
parseXml('<?xml version="1.0"?><?xml-stylesheet href="a.xsl"?><a/>'); // OK
```

Per XML 1.0:

- An XML declaration is `'<?xml' VersionInfo …` where `VersionInfo ::= S 'version' …`
  — the `<?xml` must be followed by whitespace.
- `PITarget ::= Name - (('X'|'x')('M'|'m')('L'|'l'))` subtracts only the exact
  3-letter name `xml`; `xml-stylesheet` / `xml-model` are distinct, valid Names.
- `prolog ::= XMLDecl? Misc*` and `Misc ::= Comment | PI | S` (§2.8) allow a
  processing instruction as the first item when no declaration is present.

The names-beginning-with-`xml`-are-reserved note (§2.3) is a standardization
reservation, not a well-formedness constraint — processors must accept such names
(the same reason `xmlns` is legal).

### Fix

After consuming `<?xml`, if the next character is a name character this is a PI
whose target begins with `xml`: rewind and let it be parsed as a processing
instruction (the caller's `Misc*` loop handles it). `<?xml` followed by
whitespace (a real declaration) or by a non-name character (e.g. `<?xml?>`, whose
bare `xml` target is reserved and has no valid interpretation) is unchanged.

### Test

Added a case asserting `<?xml-stylesheet?>` at document start parses as a PI with
the root element following. Repointed the existing "invalid XML declaration" test
to `<?xml?>` (still correctly rejected). Full suite green (1380 passing) at 100%
coverage.
